### PR TITLE
Simplify URLs.

### DIFF
--- a/cove_bods/test_functional.py
+++ b/cove_bods/test_functional.py
@@ -4,7 +4,6 @@ import pytest
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 
-PREFIX_OCDS = os.environ.get('PREFIX_OCDS', '/review/')
 
 BROWSER = os.environ.get('BROWSER', 'ChromeHeadless')
 
@@ -25,9 +24,9 @@ def browser(request):
 @pytest.fixture(scope='module')
 def server_url(request, live_server):
     if 'CUSTOM_SERVER_URL' in os.environ:
-        return os.environ['CUSTOM_SERVER_URL'] + PREFIX_OCDS
+        return os.environ['CUSTOM_SERVER_URL']
     else:
-        return live_server.url + PREFIX_OCDS
+        return live_server.url
 
 
 @pytest.mark.parametrize(('link_text', 'expected_text', 'css_selector', 'url'), [

--- a/cove_project/urls.py
+++ b/cove_project/urls.py
@@ -1,19 +1,9 @@
-from django.conf.urls import url, include
-from django.views.generic import RedirectView
+from django.conf.urls import url
 from django.conf.urls.static import static
 from django.conf import settings
-from cove.urls import urlpatterns as urlpatterns_core
-
+from cove.urls import urlpatterns
 import cove_bods.views
 
-
-# Serve the OCDS validator at /validator/
-urlpatterns_core += [url(r'^data/(.+)$', cove_bods.views.explore_bods, name='explore')]
-
-urlpatterns = [
-    url(r'^$', RedirectView.as_view(url='review/', permanent=False)),
-    url('^validator/', include(urlpatterns_core)),
-    url('^review/', include(urlpatterns_core)),
-]
+urlpatterns += [url(r'^data/(.+)$', cove_bods.views.explore_bods, name='explore')]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
We don't need the complexity of serving everthing under a sub directory.

Also, we were duplicating URL's which was generating warnings:

    ?: (urls.W005) URL namespace 'admin' isn't unique. You may not be able to reverse all URLs in this namespace