### PR TITLE
refactor: Rename schema attributes to rm release, as in latest lib-cove

### DIFF
--- a/cove_bods/views.py
+++ b/cove_bods/views.py
@@ -76,14 +76,14 @@ def explore_bods(request, pk):
         schema_bods = SchemaBODS(json_data=json_data, lib_cove_bods_config=lib_cove_bods_config)
 
         context.update(convert_json(upload_dir, upload_url, file_name, lib_cove_bods_config,
-                                    schema_url=schema_bods.release_pkg_schema_url, replace=True,
+                                    schema_url=schema_bods.pkg_schema_url, replace=True,
                                     request=request, flatten=True))
 
     else:
 
         schema_bods = SchemaBODS(lib_cove_bods_config=lib_cove_bods_config)
         context.update(convert_spreadsheet(upload_dir, upload_url, file_name, file_type, lib_cove_bods_config,
-                                           schema_url=schema_bods.release_pkg_schema_url))
+                                           schema_url=schema_bods.pkg_schema_url))
         with open(context['converted_path'], encoding='utf-8') as fp:
             json_data = json.load(fp, parse_float=Decimal)
         # Create schema_bods again now that we have json_data (this will pick

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,5 @@ dealer
 Django>2.2,<2.3
 # Lock this version of jsonschema, as that's what some of our libraries lock
 jsonschema<2.7
--e git+https://github.com/OpenDataServices/flatten-tool.git@v0.5.0#egg=flattentool
-libcovebods>=0.7.0
+libcovebods>=0.8.0
 -e git+https://github.com/OpenDataServices/lib-cove-web.git@v0.14.0#egg=libcoveweb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 dealer==2.1.0
-Django==2.2.13
+Django==2.2.16
 # Lock this version of jsonschema, as that's what some of our libraries lock
 jsonschema==2.6.0
--e git+https://github.com/OpenDataServices/flatten-tool.git@4c13ef0b32a59e810919a3de09bc8f64ce8f9392#egg=flattentool
-libcovebods==0.7.0
+libcovebods==0.8.0
 -e git+https://github.com/OpenDataServices/lib-cove-web.git@73654b76161dabe1d406cd28f8aca7fd94dceafb#egg=libcoveweb
 ## The following requirements were added by pip freeze:
 bleach==3.1.5
@@ -12,19 +11,22 @@ certifi==2020.6.20
 chardet==3.0.4
 commonmark==0.9.1
 contextlib2==0.6.0.post1
-django-bootstrap3==14.0.0
+defusedxml==0.6.0
+django-bootstrap3==14.1.0
 django-debug-toolbar==2.2
 django-environ==0.4.5
 et-xmlfile==1.0.1
-idna==2.9
-importlib-metadata==1.6.1
+flattentool==0.11.0
+idna==2.10
+importlib-metadata==1.7.0
 jdcal==1.4.1
 json-merge-patch==0.2
 jsonref==0.2
 LEPL==5.1.3
-libcove==0.17.0
-lxml==4.5.1
-openpyxl==3.0.4
+libcove==0.18.0
+lxml==4.5.2
+odfpy==1.4.1
+openpyxl==2.6.4
 packaging==20.4
 
 pyparsing==2.4.7
@@ -34,11 +36,11 @@ requests==2.24.0
 rfc3987==1.3.8
 rfc6266==0.0.4
 schema==0.7.2
-sentry-sdk==0.15.1
+sentry-sdk==0.17.3
 six==1.15.0
 sqlparse==0.3.1
 strict-rfc3339==0.7
-urllib3==1.25.9
+urllib3==1.25.10
 webencodings==0.5.1
 xmltodict==0.12.0
 zipp==1.2.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,42 +1,45 @@
 dealer==2.1.0
-Django==2.2.13
+Django==2.2.16
 # Lock this version of jsonschema, as that's what some of our libraries lock
 jsonschema==2.6.0
--e git+https://github.com/OpenDataServices/flatten-tool.git@4c13ef0b32a59e810919a3de09bc8f64ce8f9392#egg=flattentool
-libcovebods==0.7.0
+libcovebods==0.8.0
 -e git+https://github.com/OpenDataServices/lib-cove-web.git@73654b76161dabe1d406cd28f8aca7fd94dceafb#egg=libcoveweb
 
-pytest==5.4.3
+pytest==6.0.1
 pytest-django==3.9.0
 flake8==3.8.3
 pytest-localserver==0.5.0
 selenium==3.141.0
-transifex-client==0.13.10
+transifex-client==0.13.11
 ## The following requirements were added by pip freeze:
-attrs==19.3.0
+attrs==20.1.0
 bleach==3.1.5
 cached-property==1.5.1
 certifi==2020.6.20
 chardet==3.0.4
 commonmark==0.9.1
 contextlib2==0.6.0.post1
-django-bootstrap3==14.0.0
+defusedxml==0.6.0
+django-bootstrap3==14.1.0
 django-debug-toolbar==2.2
 django-environ==0.4.5
 et-xmlfile==1.0.1
+flattentool==0.11.0
 gitdb==4.0.5
-GitPython==3.1.3
-idna==2.9
-importlib-metadata==1.6.1
+GitPython==3.1.7
+idna==2.10
+importlib-metadata==1.7.0
+iniconfig==1.0.1
 jdcal==1.4.1
 json-merge-patch==0.2
 jsonref==0.2
 LEPL==5.1.3
-libcove==0.17.0
-lxml==4.5.1
+libcove==0.18.0
+lxml==4.5.2
 mccabe==0.6.1
-more-itertools==8.4.0
-openpyxl==3.0.4
+more-itertools==8.5.0
+odfpy==1.4.1
+openpyxl==2.6.4
 packaging==20.4
 
 pluggy==0.13.1
@@ -45,20 +48,20 @@ pycodestyle==2.6.0
 pyflakes==2.2.0
 pyparsing==2.4.7
 python-dateutil==2.8.1
-python-slugify==4.0.0
+python-slugify==4.0.1
 pytz==2020.1
 requests==2.24.0
 rfc3987==1.3.8
 rfc6266==0.0.4
 schema==0.7.2
-sentry-sdk==0.15.1
+sentry-sdk==0.17.3
 six==1.15.0
 smmap==3.0.4
 sqlparse==0.3.1
 strict-rfc3339==0.7
 text-unidecode==1.3
-urllib3==1.25.9
-wcwidth==0.2.5
+toml==0.10.1
+urllib3==1.25.10
 webencodings==0.5.1
 Werkzeug==1.0.1
 xmltodict==0.12.0


### PR DESCRIPTION
(and in latest lib-cove-bods)

See https://github.com/OpenDataServices/lib-cove/pull/55