### PR TITLE
Update requirements to include latest flatten-tool, and libcoveweb from PyPI

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,4 +3,4 @@ Django>2.2,<2.3
 # Lock this version of jsonschema, as that's what some of our libraries lock
 jsonschema<2.7
 libcovebods>=0.8.0
--e git+https://github.com/OpenDataServices/lib-cove-web.git@v0.14.0#egg=libcoveweb
+libcoveweb>=0.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ django-bootstrap3==14.1.0
 django-debug-toolbar==2.2
 django-environ==0.4.5
 et-xmlfile==1.0.1
-flattentool==0.11.0
+flattentool==0.12.0
 idna==2.10
 importlib-metadata==1.7.0
 jdcal==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Django==2.2.16
 # Lock this version of jsonschema, as that's what some of our libraries lock
 jsonschema==2.6.0
 libcovebods==0.8.0
--e git+https://github.com/OpenDataServices/lib-cove-web.git@73654b76161dabe1d406cd28f8aca7fd94dceafb#egg=libcoveweb
+libcoveweb==0.16.0
 ## The following requirements were added by pip freeze:
 bleach==3.1.5
 cached-property==1.5.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -24,7 +24,7 @@ django-bootstrap3==14.1.0
 django-debug-toolbar==2.2
 django-environ==0.4.5
 et-xmlfile==1.0.1
-flattentool==0.11.0
+flattentool==0.12.0
 gitdb==4.0.5
 GitPython==3.1.7
 idna==2.10

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ Django==2.2.16
 # Lock this version of jsonschema, as that's what some of our libraries lock
 jsonschema==2.6.0
 libcovebods==0.8.0
--e git+https://github.com/OpenDataServices/lib-cove-web.git@73654b76161dabe1d406cd28f8aca7fd94dceafb#egg=libcoveweb
+libcoveweb==0.16.0
 
 pytest==6.0.1
 pytest-django==3.9.0

--- a/update_requirements.sh
+++ b/update_requirements.sh
@@ -8,24 +8,25 @@
 rm -rf .ve
 virtualenv --python=python3 .ve
 source .ve/bin/activate
+pip install --upgrade pip
 
 if [[ "$1" == "--new-only" ]]; then
     # If --new-only is supplied then we install the current versions of
     # packages into the virtualenv, so that the only change will be any new
     # packages and their dependencies.
-    pip install -r requirements.txt
+    pip install --use-feature=2020-resolver -r requirements.txt
     dashupgrade=""
 else
     dashupgrade="--upgrade"
 fi
-pip install $dashupgrade -r requirements.in
+pip install --use-feature=2020-resolver $dashupgrade -r requirements.in
 pip freeze -r requirements.in > requirements.txt
 
 # Same again for requirements_dev
 if [[ "$1" == "--new-only" ]]; then
-    pip install -r requirements_dev.txt
+    pip install --use-feature=2020-resolver -r requirements_dev.txt
 fi
-pip install $dashupgrade -r requirements_dev.in
+pip install --use-feature=2020-resolver $dashupgrade -r requirements_dev.in
 cat requirements.in requirements_dev.in > requirements_combined_tmp.in
 pip freeze -r requirements_combined_tmp.in > requirements_dev.txt
 rm requirements_combined_tmp.in


### PR DESCRIPTION
Once deployed, this will fix https://github.com/openownership/cove-bods/issues/35, as that's fixed in the latest flatten-tool release.

libcoveweb is now on PyPI, so can be upgraded like a normal package, instead of a git url.

This also switches to pip's new 2020-resolver in the `update_requirements.sh` script. This will be the default from the October pip release. 

The new resolver is stricter, but easier to reason about. At the moment if "A requires B which requires D(v1)" and "A requires C which requires D(v2)" then the installation will happen successfully, with D(v1) or D(v2) picked depending on the order the requirements are listed. With the new resolver, this case will error out, and D will not be installed.