### PR TITLE
requirements: Roll back openpyxl to 3.0.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ lxml==4.6.3
     # via flattentool
 odfpy==1.4.1
     # via flattentool
-openpyxl==3.0.8
+openpyxl==3.0.7
     # via flattentool
 persistent==4.7.0
     # via

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -126,7 +126,7 @@ odfpy==1.4.1
     # via
     #   -r requirements.txt
     #   flattentool
-openpyxl==3.0.8
+openpyxl==3.0.7
     # via
     #   -r requirements.txt
     #   flattentool


### PR DESCRIPTION
3.0.8 has vanished.

Someone else has asked the question about this at:
https://foss.heptapod.net/openpyxl/openpyxl/-/issues/1747